### PR TITLE
Support for gatling binary format

### DIFF
--- a/gatlingparser/decoders.go
+++ b/gatlingparser/decoders.go
@@ -1,0 +1,359 @@
+package gatlingparser
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strings"
+)
+
+const (
+	RunHeaderType byte = iota
+	RequestRecordType
+	UserRecordType
+	GroupRecordType
+	ErrorRecordType
+)
+
+func ReadInt(reader *bufio.Reader) (int32, error) {
+	var int32Value int32
+	err := binary.Read(reader, binary.BigEndian, &int32Value)
+	return int32Value, err
+}
+
+func ReadLong(reader *bufio.Reader) (int64, error) {
+	var int64Value int64
+	err := binary.Read(reader, binary.BigEndian, &int64Value)
+	return int64Value, err
+}
+
+func sanitize(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(s, "\n", " "), "\r", " "), "\t", " ")
+}
+
+func ReadString(reader *bufio.Reader) (string, error) {
+	strLength, err := ReadInt(reader)
+	if err != nil {
+		return "", err
+	}
+
+	if strLength == 0 {
+		return "", nil
+	}
+
+	if strLength < 0 {
+		return "", fmt.Errorf("invalid string length: %d", strLength)
+	}
+
+	strBytes := make([]byte, strLength)
+	_, err = reader.Read(strBytes)
+	if err != nil {
+		return "", err
+	}
+	// skip byte of internal Java string serialization format ('coder' field in String class)
+	reader.ReadByte()
+	return string(strBytes), nil
+}
+
+func ReadSanitizedString(reader *bufio.Reader) (string, error) {
+	str, err := ReadString(reader)
+	if err != nil {
+		return "", err
+	}
+	return sanitize(str), nil
+}
+
+var stringCache = make(map[int32]string)
+
+func ReadCachedSanitizedString(reader *bufio.Reader) (string, error) {
+	cachedIndex, err := ReadInt(reader)
+	if err != nil {
+		return "", err
+	}
+
+	if cachedIndex >= 0 {
+		str, err := ReadString(reader)
+		if err != nil {
+			return "", err
+		}
+		sanitizedStr := sanitize(str)
+		stringCache[cachedIndex] = sanitizedStr
+		return sanitizedStr, nil
+	} else {
+		cachedString, exists := stringCache[-cachedIndex]
+		if !exists {
+			return "", fmt.Errorf("cached string missing for index %d", -cachedIndex)
+		}
+		return cachedString, nil
+	}
+}
+
+func ReadBool(reader *bufio.Reader) (bool, error) {
+	boolByte, err := reader.ReadByte()
+	if err != nil {
+		return false, err
+	}
+	return boolByte != 0, nil // transform byte to bool
+}
+
+func ReadByteArray(reader *bufio.Reader) ([]byte, error) {
+	bytesLength, err := ReadInt(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	if bytesLength == 0 {
+		return []byte{}, nil
+	}
+
+	if bytesLength < 0 {
+		return nil, fmt.Errorf("invalid bytes length: %d", bytesLength)
+	}
+
+	bytes := make([]byte, bytesLength)
+	_, err = reader.Read(bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes, nil
+}
+
+func ReadRunMessage(reader *bufio.Reader) (RunMessage, error) {
+	var result RunMessage
+	var err error
+
+	result.GatlingVersion, err = ReadString(reader)
+	if err != nil {
+		return result, err
+	}
+
+	result.SimulationClassName, err = ReadString(reader)
+	if err != nil {
+		return result, err
+	}
+
+	result.Start, err = ReadLong(reader)
+	if err != nil {
+		return result, err
+	}
+
+	result.RunDescription, err = ReadString(reader)
+	if err != nil {
+		return result, err
+	}
+	result.SimulationId = "" // not used
+
+	return result, nil
+}
+
+func ReadHeader(reader *bufio.Reader) (RunMessage, []string, [][]byte, error) {
+	var message RunMessage
+
+	message, err := ReadRunMessage(reader)
+	if err != nil {
+		return message, nil, nil, err
+	}
+
+	scenariosNumber, err := ReadInt(reader)
+	if err != nil {
+		return message, nil, nil, err
+	}
+
+	scenarios := make([]string, scenariosNumber)
+
+	for i := 0; i < int(scenariosNumber); i++ {
+		scenarios[i], err = ReadSanitizedString(reader)
+		if err != nil {
+			return message, nil, nil, err
+		}
+	}
+
+	assertionsNumber, err := ReadInt(reader)
+	if err != nil {
+		return message, nil, nil, err
+	}
+
+	assertions := make([][]byte, assertionsNumber)
+
+	for i := 0; i < int(assertionsNumber); i++ {
+		assertions[i], err = ReadByteArray(reader)
+		if err != nil {
+			return message, nil, nil, err
+		}
+	}
+
+	return message, scenarios, assertions, nil
+
+}
+
+func ReadGroup(reader *bufio.Reader) (*Group, error) {
+	hierarchyLength, err := ReadInt(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	hierarchy := make([]string, hierarchyLength)
+	for i := int32(0); i < hierarchyLength; i++ {
+		hierarchy[i], err = ReadCachedSanitizedString(reader)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &Group{Hierarchy: hierarchy}, nil
+}
+
+func ReadRequestRecord(reader *bufio.Reader, runStartTimestamp int64) (RequestRecord, error) {
+	var record RequestRecord
+
+	group, err := ReadGroup(reader)
+	if err != nil {
+		return record, err
+	}
+	record.Group = group
+
+	record.Name, err = ReadCachedSanitizedString(reader)
+	if err != nil {
+		return record, err
+	}
+
+	start, err := ReadInt(reader)
+	if err != nil {
+		return record, err
+	}
+	record.StartTimestamp = int64(start) + runStartTimestamp
+
+	end, err := ReadInt(reader)
+	if err != nil {
+		return record, err
+	}
+	record.EndTimestamp = int64(end) + runStartTimestamp
+
+	record.Status, err = ReadBool(reader)
+	if err != nil {
+		return record, err
+	}
+
+	errorMessage, err := ReadCachedSanitizedString(reader)
+	if err != nil {
+		return record, err
+	}
+	if errorMessage != "" {
+		record.ErrorMessage = &errorMessage
+	}
+
+	record.ResponseTime = int32(record.EndTimestamp - record.StartTimestamp)
+
+	if record.EndTimestamp != math.MinInt64 {
+		record.Incoming = false
+	} else {
+		record.Incoming = true
+	}
+
+	return record, nil
+}
+
+func ReadGroupRecord(reader *bufio.Reader, runStartTimestamp int64) (GroupRecord, error) {
+	var record GroupRecord
+
+	group, err := ReadGroup(reader)
+	if err != nil {
+		return record, err
+	}
+	record.Group = *group
+
+	start, err := ReadInt(reader)
+	if err != nil {
+		return record, err
+	}
+	record.StartTimestamp = int64(start) + runStartTimestamp
+
+	end, err := ReadInt(reader)
+	if err != nil {
+		return record, err
+	}
+	record.EndTimestamp = int64(end) + runStartTimestamp
+
+	record.CumulatedResponseTime, err = ReadInt(reader)
+	if err != nil {
+		return record, err
+	}
+
+	record.Status, err = ReadBool(reader)
+	if err != nil {
+		return record, err
+	}
+
+	record.Duration = int32(record.EndTimestamp - record.StartTimestamp)
+
+	return record, nil
+}
+
+func ReadUserRecord(reader *bufio.Reader, runStartTimestamp int64, scenarios []string) (UserRecord, error) {
+	var record UserRecord
+
+	scenarioIndex, err := ReadInt(reader)
+	if err != nil {
+		return record, err
+	}
+
+	// Get scenario by index
+	if scenarioIndex < 0 || scenarioIndex >= int32(len(scenarios)) {
+		return record, fmt.Errorf("invalid scenario index: %d", scenarioIndex)
+	}
+	record.Scenario = scenarios[scenarioIndex]
+
+	// read Start or Stop UserEvent
+	record.Event, err = ReadBool(reader)
+	if err != nil {
+		return record, err
+	}
+
+	timestamp, err := ReadInt(reader)
+	if err != nil {
+		return record, err
+	}
+	record.Timestamp = int64(timestamp) + runStartTimestamp
+
+	return record, nil
+}
+
+func ReadErrorRecord(reader *bufio.Reader, runStartTimestamp int64) (ErrorRecord, error) {
+	var record ErrorRecord
+
+	message, err := ReadCachedSanitizedString(reader)
+	if err != nil {
+		return record, err
+	}
+
+	timestamp, err := ReadInt(reader)
+	if err != nil {
+		return record, err
+	}
+	record.Timestamp = int64(timestamp) + runStartTimestamp
+	record.Message = message
+
+	return record, nil
+}
+
+func ReadNotHeaderRecord(reader *bufio.Reader, runStartTimestapm int64, scenarios []string) (interface{}, error) {
+	recordType, err := reader.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+
+	switch recordType {
+	case RequestRecordType:
+		return ReadRequestRecord(reader, runStartTimestapm)
+	case GroupRecordType:
+		return ReadGroupRecord(reader, runStartTimestapm)
+	case UserRecordType:
+		return ReadUserRecord(reader, runStartTimestapm, scenarios)
+	case ErrorRecordType:
+		return ReadErrorRecord(reader, runStartTimestapm)
+	default:
+		return nil, fmt.Errorf("unknown record type: %d", recordType)
+	}
+}

--- a/gatlingparser/records.go
+++ b/gatlingparser/records.go
@@ -1,0 +1,203 @@
+package gatlingparser
+
+import (
+	"fmt"
+	client "github.com/influxdata/influxdb1-client/v2"
+	"github.com/perfana/x2i/influx"
+	"math/rand"
+	"strings"
+	"time"
+)
+
+type RunMessage struct {
+	SimulationClassName string
+	SimulationId        string
+	Start               int64
+	RunDescription      string
+	GatlingVersion      string
+}
+
+func (rm RunMessage) String() string {
+	return fmt.Sprintf("Gatling log:\n\tversion: %s\n\tclassName: %s\n\tstart: %s\n", rm.GatlingVersion, rm.SimulationClassName, time.UnixMilli(rm.Start))
+}
+
+func (rm RunMessage) ToInfluxPoint(testStartTime time.Time) (*client.Point, error) {
+	return influx.NewPoint(
+		"tests",
+		map[string]string{
+			"action":          "start",
+			"simulation":      simulationName,
+			"systemUnderTest": systemUnderTest,
+			"testEnvironment": testEnvironment,
+			"nodeName":        nodeName,
+		},
+		map[string]interface{}{
+			"description": rm.RunDescription,
+		},
+		testStartTime,
+	)
+}
+
+type RequestRecord struct {
+	Group          *Group
+	Name           string
+	Status         bool
+	StartTimestamp int64
+	EndTimestamp   int64
+	ResponseTime   int32
+	ErrorMessage   *string
+	Incoming       bool
+}
+
+func (rr RequestRecord) String() string {
+	v := "KO"
+	if rr.Status {
+		v = "OK"
+	}
+	return fmt.Sprintf("REQ group: %s, name: %s, start: %s, end: %s, status: %s",
+		*rr.Group,
+		rr.Name,
+		time.UnixMilli(rr.StartTimestamp),
+		time.UnixMilli(rr.EndTimestamp),
+		v,
+	)
+}
+
+func toInfluxTimestamp(millis int64) time.Time {
+	return time.Unix(0, millis*oneMillisecond+rand.Int63n(oneMillisecond))
+}
+
+func statusToString(status bool) string {
+	statusString := "KO"
+	if status {
+		statusString = "OK"
+	}
+	return statusString
+}
+
+func (rr RequestRecord) ToInfluxPoint() (*client.Point, error) {
+	timestamp := toInfluxTimestamp(rr.EndTimestamp)
+	groupString := strings.TrimSpace(strings.Join(rr.Group.Hierarchy, "_"))
+	statusString := statusToString(rr.Status)
+	errorMessage := ""
+	if rr.ErrorMessage != nil {
+		errorMessage = *rr.ErrorMessage
+	}
+
+	return influx.NewPoint(
+		"requests",
+		map[string]string{
+			"name":            strings.TrimSpace(strings.ReplaceAll(rr.Name, " ", "_")),
+			"groups":          groupString,
+			"result":          statusString,
+			"simulation":      simulationName,
+			"systemUnderTest": systemUnderTest,
+			"testEnvironment": testEnvironment,
+			"nodeName":        nodeName,
+			"errorMessage":    errorMessage,
+		},
+		map[string]interface{}{
+			"duration": int(rr.EndTimestamp - rr.StartTimestamp),
+		},
+		timestamp,
+	)
+}
+
+type GroupRecord struct {
+	Group                 Group
+	Duration              int32
+	CumulatedResponseTime int32
+	Status                bool
+	StartTimestamp        int64
+	EndTimestamp          int64
+}
+
+func (gr GroupRecord) ToInfluxPoint() (*client.Point, error) {
+	timestamp := toInfluxTimestamp(gr.EndTimestamp)
+	groupString := strings.TrimSpace(strings.Join(gr.Group.Hierarchy, "_"))
+	statusString := statusToString(gr.Status)
+
+	return influx.NewPoint(
+		"groups",
+		map[string]string{
+			"name":            groupString,
+			"result":          statusString,
+			"simulation":      simulationName,
+			"systemUnderTest": systemUnderTest,
+			"testEnvironment": testEnvironment,
+			"nodeName":        nodeName,
+		},
+		map[string]interface{}{
+			"totalDuration": int(gr.EndTimestamp - gr.StartTimestamp),
+			"rawDuration":   int(gr.CumulatedResponseTime),
+		},
+		timestamp,
+	)
+}
+
+func (gr GroupRecord) String() string {
+	return fmt.Sprintf("GRO group: %s, start: %s, end: %s, cumulatedResponseTime: %d",
+		gr.Group,
+		time.UnixMilli(gr.StartTimestamp),
+		time.UnixMilli(gr.EndTimestamp),
+		gr.CumulatedResponseTime,
+	)
+}
+
+type UserRecord struct {
+	Scenario  string
+	Event     bool
+	Timestamp int64
+}
+
+func eventToSting(event bool) string {
+	eventString := "END"
+	if event {
+		eventString = "START"
+	}
+	return eventString
+}
+
+func (ur UserRecord) String() string {
+	event := eventToSting(ur.Event)
+	return fmt.Sprintf("USR scenario: %s, event: %s, timestamp: %s",
+		ur.Scenario,
+		event,
+		time.UnixMilli(ur.Timestamp),
+	)
+}
+
+func (ur UserRecord) ToInfluxUserLineParams() (time.Time, string, string) {
+	timestamp := toInfluxTimestamp(ur.Timestamp)
+	return timestamp, ur.Scenario, eventToSting(ur.Event)
+}
+
+type ErrorRecord struct {
+	Message   string
+	Timestamp int64
+}
+
+func (er ErrorRecord) ToInfluxPoint() (*client.Point, error) {
+	timestamp := toInfluxTimestamp(er.Timestamp)
+	return influx.NewPoint(
+		"errors",
+		map[string]string{
+			"systemUnderTest": systemUnderTest,
+			"testEnvironment": testEnvironment,
+			"nodeName":        nodeName,
+			"simulation":      simulationName,
+		},
+		map[string]interface{}{
+			"errorMessage": er.Message,
+		},
+		timestamp,
+	)
+}
+
+type Group struct {
+	Hierarchy []string
+}
+
+func (g Group) String() string {
+	return fmt.Sprintf("%s", g.Hierarchy)
+}


### PR DESCRIPTION
Since version 3.12.1, the `simulation.log` format has been changed to binary and more compact. I added support for binary Gatling logs. There are decoders for all types of records except assertions, because they still need to be decoded using pickle-decoders, and it seems that asserts are not needed in Influx. Asserts are stored in the code simply as bytes.

I checked it locally on Influx 1.8 on a file from Gatling (tests)[https://github.com/gatling/gatling/blob/main/gatling-charts/src/test/resources/known_stats/simulation.log], everything was decoded and written well. I also tried to run small tests for 1-2 minutes on a fresh Gatling, it also worked fine.

I also made it backwards compatible with the old format. That is, based on the first lines of the simulation.log, it is determined which parser to use for the old or new format.

*P.S.* I haven't written much in Go, maybe something there should be done more idiomatically

Closes #5 